### PR TITLE
External ID, timeframe

### DIFF
--- a/contacts/models.py
+++ b/contacts/models.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import timedelta
 
+from django.conf import settings
 from django.db import models
 from django.db.models import ExpressionWrapper, F, fields
 from django.utils import timezone
@@ -45,7 +46,7 @@ class CaseManager(models.Manager):
 
     def with_end_date(self):
         date_end_expression = ExpressionWrapper(
-            expression=F("date_start") + timedelta(days=14),
+            expression=F("date_start") + timedelta(days=settings.TIMEFRAME),
             output_field=fields.DateTimeField(),
         )
         return self.annotate(contact_date_end=date_end_expression)
@@ -76,4 +77,4 @@ class Case(models.Model):
 
     @property
     def date_end(self):
-        return self.date_start + timedelta(days=14)
+        return self.date_start + timedelta(days=settings.TIMEFRAME)

--- a/contacts/serializers.py
+++ b/contacts/serializers.py
@@ -29,7 +29,6 @@ class ContactSerializer(serializers.ModelSerializer):
 
 class CaseSerializer(serializers.ModelSerializer):
     timestamp = serializers.DateTimeField(source="date_start", write_only=True)
-    external_id = serializers.CharField(required=True)
     created_by = serializers.SerializerMethodField()
 
     def validate(self, data):

--- a/healthcheck/settings/base.py
+++ b/healthcheck/settings/base.py
@@ -109,6 +109,8 @@ STATICFILES_FINDERS = (
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 MEDIA_URL = "/media/"
 
+TIMEFRAME = env.int("TIMEFRAME", 14)
+
 # Other config variables
 AUTH_USER_MODEL = "users.User"
 


### PR DESCRIPTION
minor changes - external id no longer required; time period configurable with `TIMEFRAME` env variable, defaults to 14 days