### PR TITLE
Selfswab polling hacky retry for Requisition mismatch

### DIFF
--- a/healthcheck/settings/base.py
+++ b/healthcheck/settings/base.py
@@ -176,3 +176,5 @@ TBCONNECT_BQ_DATASET = env.str("TBCONNECT_BQ_DATASET", "wassup-165700.tbconnect"
 
 SELFSWAB_BQ_KEY_PATH = env.str("SELFSWAB_BQ_KEY_PATH", "bq_credentials.json")
 SELFSWAB_BQ_DATASET = env.str("SELFSWAB_BQ_DATASET", "wassup-165700.selfswab")
+
+SELFSWAB_RETRY_HOURS = env.int("SELFSWAB_RETRY_HOURS", 8)

--- a/healthcheck/tests/test_utils.py
+++ b/healthcheck/tests/test_utils.py
@@ -85,7 +85,7 @@ class UtilsTests(TestCase):
                 "barcode": "111",
                 "msisdn": "+123",
                 "contact_id": "test1",
-                "result": SelfSwabTest.RESULT_PENDING,
+                "result": SelfSwabTest.Result.PENDING,
                 "should_sync": False,
             }
         )
@@ -94,7 +94,7 @@ class UtilsTests(TestCase):
                 "barcode": "222",
                 "msisdn": "+124",
                 "contact_id": "test2",
-                "result": SelfSwabTest.RESULT_PENDING,
+                "result": SelfSwabTest.Result.PENDING,
             }
         )
 

--- a/selfswab/models.py
+++ b/selfswab/models.py
@@ -139,33 +139,23 @@ class SelfSwabScreen(models.Model, BaseModel):
 
 
 class SelfSwabTest(models.Model):
-    RESULT_PENDING = "Pending"
-    RESULT_POSITIVE = "Positive"
-    RESULT_NEGATIVE = "Negative"
-    RESULT_REJECTED = "Rejected"
-    RESULT_INVALID = "Invalid"
-    RESULT_EQUIVOCAL = "Equivocal"
-    RESULT_INCONCLUSIVE = "Inconclusive"
-    RESULT_INDETERMINATE = "Indeterminate"
-    RESULT_ERROR = "Error"
-    RESULT_TYPES = (
-        (RESULT_PENDING, "Pending"),
-        (RESULT_POSITIVE, "Positive"),
-        (RESULT_NEGATIVE, "Negative"),
-        (RESULT_REJECTED, "Rejected"),
-        (RESULT_INVALID, "Invalid"),
-        (RESULT_EQUIVOCAL, "Equivocal"),
-        (RESULT_INCONCLUSIVE, "Inconclusive"),
-        (RESULT_INDETERMINATE, "Indeterminate"),
-        (RESULT_ERROR, "Error"),
-    )
+    class Result(models.TextChoices):
+        PENDING = "Pending", "Pending"
+        POSITIVE = "Positive", "Positive"
+        NEGATIVE = "Negative", "Negative"
+        REJECTED = "Rejected", "Rejected"
+        INVALID = "Invalid", "Invalid"
+        EQUIVOCAL = "Equivocal", "Equivocal"
+        INCONCLUSIVE = "Inconclusive", "Inconclusive"
+        INDETERMINATE = "Indeterminate", "Indeterminate"
+        ERROR = "Error", "Error"
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     created_by = models.CharField(max_length=255, blank=True, default="")
     contact_id = models.CharField(max_length=255, blank=False)
     msisdn = models.CharField(max_length=255, validators=[za_phone_number])
     result = models.CharField(
-        max_length=100, choices=RESULT_TYPES, default=RESULT_PENDING
+        max_length=100, choices=Result.choices, default=Result.PENDING
     )
     barcode = models.CharField(max_length=255, blank=False, unique=True)
     timestamp = models.DateTimeField(default=timezone.now)
@@ -206,18 +196,18 @@ class SelfSwabTest(models.Model):
 
     def set_result(self, result):
         if result.upper() in ["POS", "POSITIVE", "DETECTED"]:
-            self.result = SelfSwabTest.RESULT_POSITIVE
+            self.result = SelfSwabTest.Result.POSITIVE
         elif result.upper() in ["NEG", "NEGATIVE", "NOT DET", "NOT DETECTED"]:
-            self.result = SelfSwabTest.RESULT_NEGATIVE
+            self.result = SelfSwabTest.Result.NEGATIVE
         elif result.upper() in ["INV", "INVALID"]:
-            self.result = SelfSwabTest.RESULT_INVALID
+            self.result = SelfSwabTest.Result.INVALID
         elif result.upper() in ["REJECTED", "REJ"]:
-            self.result = SelfSwabTest.RESULT_REJECTED
+            self.result = SelfSwabTest.Result.REJECTED
         elif result.upper() in ["EQV", "EQUIVOCAL"]:
-            self.result = SelfSwabTest.RESULT_EQUIVOCAL
+            self.result = SelfSwabTest.Result.EQUIVOCAL
         elif result.upper() in ["INC", "INCON", "INCONCLUSIVE"]:
-            self.result = SelfSwabTest.RESULT_INCONCLUSIVE
+            self.result = SelfSwabTest.Result.INCONCLUSIVE
         elif result.upper() in ["INDETERMINATE", "IND"]:
-            self.result = SelfSwabTest.RESULT_INDETERMINATE
+            self.result = SelfSwabTest.Result.INDETERMINATE
         else:
-            self.result = SelfSwabTest.RESULT_ERROR
+            self.result = SelfSwabTest.Result.ERROR

--- a/selfswab/tasks.py
+++ b/selfswab/tasks.py
@@ -29,7 +29,7 @@ def poll_meditech_api_for_results():
 
             barcodes = list(
                 SelfSwabTest.objects.filter(
-                    result=SelfSwabTest.RESULT_PENDING
+                    result=SelfSwabTest.Result.PENDING
                 ).values_list("barcode", flat=True)
             )
 
@@ -45,12 +45,12 @@ def poll_meditech_api_for_results():
             response.raise_for_status()
             results = response.json()["results"]
             for result in results:
-                test_result = result.get("result", SelfSwabTest.RESULT_ERROR)
-                if test_result not in (SelfSwabTest.RESULT_PENDING, ""):
+                test_result = result.get("result", SelfSwabTest.Result.ERROR)
+                if test_result not in (SelfSwabTest.Result.PENDING, ""):
                     registration = (
                         SelfSwabTest.objects.filter(
                             barcode=result["barcode"],
-                            result=SelfSwabTest.RESULT_PENDING,
+                            result=SelfSwabTest.Result.PENDING,
                         )
                         .order_by("-timestamp")
                         .first()

--- a/selfswab/tasks.py
+++ b/selfswab/tasks.py
@@ -1,6 +1,8 @@
 from celery.decorators import periodic_task
 from celery.task.schedules import crontab
 from django.conf import settings
+from django.utils import timezone
+from datetime import timedelta
 
 from django_redis import get_redis_connection
 from temba_client.v2 import TembaClient
@@ -57,6 +59,18 @@ def poll_meditech_api_for_results():
                     )
 
                     if not registration:
+                        continue
+
+                    # This is a bit of a hack, the api to push the test to meditech
+                    # is not done yet (and won't be anytime soon) and it takes a
+                    # while for it to be manually loaded
+                    if (
+                        test_result == SelfSwabTest.Result.ERROR
+                        and result.get("error") == "Requisition mismatch"
+                        and registration.timestamp
+                        <= timezone.now()
+                        + timedelta(hours=settings.SELFSWAB_RETRY_HOURS)
+                    ):
                         continue
 
                     registration.set_result(test_result)

--- a/selfswab/tests/test_models.py
+++ b/selfswab/tests/test_models.py
@@ -23,7 +23,7 @@ class SelfSwabTestTests(TestCase):
                 "id": str(test.id),
                 "contact_id": test.contact_id,
                 "msisdn": "GyReRepLLYF5Ldr6IyA1mu8VM96Et16I0TFIyDvRmK4=",
-                "result": SelfSwabTest.RESULT_PENDING,
+                "result": SelfSwabTest.Result.PENDING,
                 "barcode": test.barcode,
                 "timestamp": test.timestamp.isoformat(),
                 "updated_at": test.updated_at.isoformat(),
@@ -37,27 +37,27 @@ class SelfSwabTestTests(TestCase):
         test = SelfSwabTest.objects.create(**{"msisdn": "+123"})
 
         test.set_result("POS")
-        self.assertEqual(test.result, SelfSwabTest.RESULT_POSITIVE)
+        self.assertEqual(test.result, SelfSwabTest.Result.POSITIVE)
         test.set_result("Positive")
-        self.assertEqual(test.result, SelfSwabTest.RESULT_POSITIVE)
+        self.assertEqual(test.result, SelfSwabTest.Result.POSITIVE)
         test.set_result("DETECTED")
-        self.assertEqual(test.result, SelfSwabTest.RESULT_POSITIVE)
+        self.assertEqual(test.result, SelfSwabTest.Result.POSITIVE)
         test.set_result("NOT DET")
-        self.assertEqual(test.result, SelfSwabTest.RESULT_NEGATIVE)
+        self.assertEqual(test.result, SelfSwabTest.Result.NEGATIVE)
         test.set_result("NOT DETECTED")
-        self.assertEqual(test.result, SelfSwabTest.RESULT_NEGATIVE)
+        self.assertEqual(test.result, SelfSwabTest.Result.NEGATIVE)
         test.set_result("INV")
-        self.assertEqual(test.result, SelfSwabTest.RESULT_INVALID)
+        self.assertEqual(test.result, SelfSwabTest.Result.INVALID)
         test.set_result("REJ")
-        self.assertEqual(test.result, SelfSwabTest.RESULT_REJECTED)
+        self.assertEqual(test.result, SelfSwabTest.Result.REJECTED)
         test.set_result("EQV")
-        self.assertEqual(test.result, SelfSwabTest.RESULT_EQUIVOCAL)
+        self.assertEqual(test.result, SelfSwabTest.Result.EQUIVOCAL)
         test.set_result("INCON")
-        self.assertEqual(test.result, SelfSwabTest.RESULT_INCONCLUSIVE)
+        self.assertEqual(test.result, SelfSwabTest.Result.INCONCLUSIVE)
         test.set_result("INDETERMINATE")
-        self.assertEqual(test.result, SelfSwabTest.RESULT_INDETERMINATE)
+        self.assertEqual(test.result, SelfSwabTest.Result.INDETERMINATE)
         test.set_result("Error")
-        self.assertEqual(test.result, SelfSwabTest.RESULT_ERROR)
+        self.assertEqual(test.result, SelfSwabTest.Result.ERROR)
 
 
 class SelfSwabScreenTests(TestCase):

--- a/selfswab/tests/test_tasks.py
+++ b/selfswab/tests/test_tasks.py
@@ -29,7 +29,7 @@ class PollMeditechForResults(TestCase):
         "extra": {"result": "Negative", "updated_at": updated_at.strftime("%d/%m/%Y")},
     }
 
-    def create_selfswab_test(self, msisdn, barcode, result=SelfSwabTest.RESULT_PENDING):
+    def create_selfswab_test(self, msisdn, barcode, result=SelfSwabTest.Result.PENDING):
         return SelfSwabTest.objects.create(
             **{
                 "id": uuid.uuid4().hex,
@@ -58,7 +58,7 @@ class PollMeditechForResults(TestCase):
         test1 = self.create_selfswab_test("27856454612", "12345678")
         test2 = self.create_selfswab_test("27895671234", "87654321")
         test3 = self.create_selfswab_test(
-            "27890001234", "12341234", SelfSwabTest.RESULT_POSITIVE
+            "27890001234", "12341234", SelfSwabTest.Result.POSITIVE
         )
 
         responses.add(
@@ -110,17 +110,17 @@ class PollMeditechForResults(TestCase):
         test2.refresh_from_db()
         test3.refresh_from_db()
 
-        self.assertEqual(test1.result, SelfSwabTest.RESULT_PENDING)
+        self.assertEqual(test1.result, SelfSwabTest.Result.PENDING)
         self.assertIsNone(test1.collection_timestamp)
         self.assertIsNone(test1.received_timestamp)
         self.assertIsNone(test1.authorized_timestamp)
 
-        self.assertEqual(test2.result, SelfSwabTest.RESULT_NEGATIVE)
+        self.assertEqual(test2.result, SelfSwabTest.Result.NEGATIVE)
         self.assertEqual(test2.collection_timestamp.isoformat(), self.test_timestamp)
         self.assertEqual(test2.received_timestamp.isoformat(), self.test_timestamp)
         self.assertEqual(test2.authorized_timestamp.isoformat(), self.test_timestamp)
 
-        self.assertEqual(test3.result, SelfSwabTest.RESULT_POSITIVE)
+        self.assertEqual(test3.result, SelfSwabTest.Result.POSITIVE)
         self.assertIsNone(test3.collection_timestamp)
         self.assertIsNone(test3.received_timestamp)
         self.assertIsNone(test3.authorized_timestamp)
@@ -227,7 +227,7 @@ class PollMeditechForResults(TestCase):
         Should handle an error response from the meditech api
         """
         self.create_selfswab_test(
-            "27856454612", "12345678", SelfSwabTest.RESULT_POSITIVE
+            "27856454612", "12345678", SelfSwabTest.Result.POSITIVE
         )
 
         poll_meditech_api_for_results()

--- a/selfswab/tests/test_views.py
+++ b/selfswab/tests/test_views.py
@@ -99,7 +99,7 @@ class SelfSwabTestViewSetTests(APITestCase, BaseEventTestCase):
             {
                 "msisdn": "27856454612",
                 "contact_id": "9e12d04c-af25-40b6-aa4f-57c72e8e3f91",
-                "result": SelfSwabTest.RESULT_NEGATIVE,
+                "result": SelfSwabTest.Result.NEGATIVE,
                 "barcode": "CP159600001",
                 "timestamp": "2020-01-11T08:30:24.922024+00:00",
                 "updated_at": "2020-01-12T08:30:24.922024+00:00",
@@ -108,7 +108,7 @@ class SelfSwabTestViewSetTests(APITestCase, BaseEventTestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         [selfswabtest] = SelfSwabTest.objects.all()
         self.assertEqual(selfswabtest.msisdn, "27856454612")
-        self.assertEqual(selfswabtest.result, SelfSwabTest.RESULT_NEGATIVE)
+        self.assertEqual(selfswabtest.result, SelfSwabTest.Result.NEGATIVE)
         self.assertEqual(
             selfswabtest.contact_id, "9e12d04c-af25-40b6-aa4f-57c72e8e3f91"
         )
@@ -134,7 +134,7 @@ class SelfSwabTestViewSetTests(APITestCase, BaseEventTestCase):
             {
                 "msisdn": "27856454612",
                 "contact_id": "9e12d04c-af25-40b6-aa4f-57c72e8e3f91",
-                "result": SelfSwabTest.RESULT_NEGATIVE,
+                "result": SelfSwabTest.Result.NEGATIVE,
                 "barcode": "CP159600001",
                 "timestamp": "2020-01-11T08:30:24.922024+00:00",
                 "updated_at": "2020-01-12T08:30:24.922024+00:00",
@@ -159,7 +159,7 @@ class SelfSwabTestViewSetTests(APITestCase, BaseEventTestCase):
             {
                 "msisdn": "27856454612",
                 "contact_id": "9e12d04c-af25-40b6-aa4f-57c72e8e3f91",
-                "result": SelfSwabTest.RESULT_NEGATIVE,
+                "result": SelfSwabTest.Result.NEGATIVE,
                 "barcode": "invalid",
                 "timestamp": "2020-01-11T08:30:24.922024+00:00",
                 "updated_at": "2020-01-12T08:30:24.922024+00:00",


### PR DESCRIPTION
Adding a retry window for a specific error because there is a delay between capturing the barcode on WA and loading it at the lab. 

This is a temporary solution until the api is done to load it from the Rapidpro flow in real time.