### PR TITLE
Exclude dynamic groups

### DIFF
--- a/selfswab/tests/test_views.py
+++ b/selfswab/tests/test_views.py
@@ -434,6 +434,35 @@ class SelfSwabWhitelistViewSetTests(APITestCase):
         )
 
         responses.add(
+            responses.GET,
+            f"https://rp-test.com/api/v2/groups.json",
+            json={
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "uuid": "8a8276de-6b58-4f82-83b7-c4ee21664c7c",
+                        "name": "Some Dynamic Group",
+                        "query": "Some Query",
+                        "count": 111,
+                    },
+                    {
+                        "uuid": "da85c55c-c213-4cfc-9d6d-c88d97993bf3",
+                        "name": "SelfSwab Whitelist",
+                        "query": None,
+                        "count": 222,
+                    },
+                    {
+                        "uuid": "5a4eb79e-1b1f-4ae3-8700-09384cca385f",
+                        "name": "Customers",
+                        "query": None,
+                        "count": 333,
+                    },
+                ],
+            },
+        )
+
+        responses.add(
             responses.POST,
             "https://rp-test.com/api/v2/contacts.json",
             json={
@@ -466,7 +495,7 @@ class SelfSwabWhitelistViewSetTests(APITestCase):
 
         self.assertEqual(response.status_code, 200)
 
-        [_, call] = responses.calls
+        [_, _, call] = responses.calls
         body = json.loads(call.request.body)
         self.assertEqual(
             body,

--- a/selfswab/tests/test_views.py
+++ b/selfswab/tests/test_views.py
@@ -544,6 +544,35 @@ class SelfSwabWhitelistViewSetTests(APITestCase):
             },
         )
 
+        responses.add(
+            responses.GET,
+            f"https://rp-test.com/api/v2/groups.json",
+            json={
+                "next": None,
+                "previous": None,
+                "results": [
+                    {
+                        "uuid": "8a8276de-6b58-4f82-83b7-c4ee21664c7c",
+                        "name": "Some Dynamic Group",
+                        "query": "Some Query",
+                        "count": 111,
+                    },
+                    {
+                        "uuid": "da85c55c-c213-4cfc-9d6d-c88d97993bf3",
+                        "name": "SelfSwab Whitelist",
+                        "query": None,
+                        "count": 222,
+                    },
+                    {
+                        "uuid": "5a4eb79e-1b1f-4ae3-8700-09384cca385f",
+                        "name": "Customers",
+                        "query": None,
+                        "count": 333,
+                    },
+                ],
+            },
+        )
+
         response = self.client.post(
             self.url,
             {

--- a/selfswab/utils.py
+++ b/selfswab/utils.py
@@ -113,3 +113,12 @@ def get_whatsapp_media(media_id):
     )
     response.raise_for_status()
     return response.content
+
+
+def exclude_dynamic_groups(rapidpro, group_ids):
+    normal_groups = []
+    all_groups = rapidpro.get_groups().all()
+    for group in all_groups:
+        if group.query is None and group.uuid in group_ids:
+            normal_groups.append(group.uuid)
+    return normal_groups


### PR DESCRIPTION
Rapidpro complains if you update the list of groups with a UUID from a dynamic group, It also overwrites the complete contact group list so you can't just send the one you are adding.