### PR TITLE
Fix docker hub repository

### DIFF
--- a/.github/workflows/qa_build.yaml
+++ b/.github/workflows/qa_build.yaml
@@ -54,7 +54,7 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository }}
-            ${{ github.repository }}
+            praekeltfoundation/healthcheck-django
           tags: |
             type=sha
       - name: login to ghcr


### PR DESCRIPTION
The name is different on docker hub, not the same as the repo name