### PR TITLE
Add caching to cases

### DIFF
--- a/covid_cases/models.py
+++ b/covid_cases/models.py
@@ -4,7 +4,7 @@ from datetime import date
 from functools import lru_cache
 
 from django.db import models
-from django.db.models import Max, Sum, constraints
+from django.db.models import Sum, constraints
 
 
 class Province(models.Model):

--- a/covid_cases/tasks.py
+++ b/covid_cases/tasks.py
@@ -3,6 +3,7 @@ from datetime import date
 import requests
 from celery.exceptions import SoftTimeLimitExceeded
 from django.conf import settings
+from django.core.cache import cache
 from django.core.files.base import ContentFile
 from django.db import transaction
 from requests.exceptions import RequestException
@@ -155,4 +156,6 @@ def scrape_sacoronavirus_case_images():
             url=image.url, image=file, date=image.date
         )
         total += 1
+    if total > 0:
+        cache.delete("latest_image")
     return f"Downloaded {total} images"

--- a/covid_cases/tests.py
+++ b/covid_cases/tests.py
@@ -3,6 +3,7 @@ import json
 from datetime import date
 
 import responses
+from django.core.cache import cache
 from django.core.files import File
 from django.test import override_settings
 from django.urls import reverse
@@ -25,13 +26,13 @@ from covid_cases.tasks import (
     scrape_sacoronavirus_homepage,
 )
 from covid_cases.utils import normalise_text
-from healthcheck.settings.base import API_DOMAIN, ENABLE_SACORONAVIRUS_SCRAPING
 
 
 def generate_mock_db_data(self):
     Province.get_province.cache_clear()
     District.get_district.cache_clear()
     SubDistrict.get_sub_district.cache_clear()
+    cache.delete("latest_image")
 
     self.province = Province.objects.create(name="Western Cape")
     self.district = District.objects.create(name="West Coast", province=self.province)

--- a/covid_cases/utils.py
+++ b/covid_cases/utils.py
@@ -1,6 +1,9 @@
 import os
 import re
+from functools import wraps
 from urllib.parse import urlparse
+
+from django.core.cache import cache
 
 
 def normalise_text(text: str) -> str:
@@ -14,3 +17,24 @@ def normalise_text(text: str) -> str:
 def get_filename_from_url(url: str) -> str:
     url = urlparse(url)
     return os.path.basename(url.path)
+
+
+def cache_method(key, expiry):
+    """
+    Uses django caching to cache the result from a method in a static key. Note that the
+    cached value doesn't change according to function arguments
+    """
+
+    def wrapper(function):
+        @wraps(function)
+        def inner(*args, **kwargs):
+            result = cache.get(key)
+            if result:
+                return result
+            result = function(*args, **kwargs)
+            cache.set(key, result, expiry)
+            return result
+
+        return inner
+
+    return wrapper

--- a/healthcheck/settings/base.py
+++ b/healthcheck/settings/base.py
@@ -35,6 +35,7 @@ INSTALLED_APPS = [
     "django_filters",
     "import_export",
     "drf_spectacular",
+    "django_celery_results",
     # monitoring apps
     "django_prometheus",
     "health_check",
@@ -157,7 +158,7 @@ CELERY_BROKER_URL = env.str("CELERY_BROKER_URL", "redis://localhost:6379/0")
 # Redis is used in dev env, RabbitMQ on production.
 BROKER_URL = env.str("CELERY_BROKER_URL", "redis://localhost:6379/0")
 REDIS_URL = env.str("REDIS_URL", "redis://localhost:6379/0")
-CELERY_RESULT_BACKEND = env.str("CELERY_RESULT_BACKEND", "redis://localhost:6379/0")
+CELERY_RESULT_BACKEND = "django-db"
 CELERY_ACCEPT_CONTENT = ["application/json"]
 CELERY_TASK_SERIALIZER = env.str("CELERY_TASK_SERIALIZER", "json")
 CELERY_RESULT_SERIALIZER = env.str("CELERY_RESULT_SERIALIZER", "json")
@@ -198,6 +199,7 @@ CACHES = {
         "BACKEND": "django_redis.cache.RedisCache",
         "LOCATION": REDIS_URL,
         "OPTIONS": {"CLIENT_CLASS": "django_redis.client.DefaultClient"},
+        "KEY_PREFIX": env.str("REDIS_PREFIX", ""),
     }
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,3 +62,4 @@ beautifulsoup4==4.10.0
 Pillow==8.4.0
 django-storages==1.12.3
 boto3==1.20.24
+django-celery-results==2.0.1


### PR DESCRIPTION
The contact ndoh cases view is one that will be queries often.

We don't want the signed image URL to change often, otherwise it breaks the caching and we have to constantly reupload the image for each new message