### PR TITLE
Fix Latitude longitude with negative values

### DIFF
--- a/healthcheck/tests/test_utils.py
+++ b/healthcheck/tests/test_utils.py
@@ -1,9 +1,10 @@
+from unittest.mock import Mock, patch
+
 from django.test import TestCase
-from unittest.mock import patch, Mock
 
 from healthcheck import utils
-from tbconnect.models import TBTest
 from selfswab.models import SelfSwabTest
+from tbconnect.models import TBTest
 
 
 class UtilsTests(TestCase):
@@ -17,6 +18,18 @@ class UtilsTests(TestCase):
         lat, long = utils.extract_reduced_accuracy_lat_long("+40.20361+40.20361")
         self.assertEqual(lat, 40.2)
         self.assertEqual(long, 40.2)
+
+        lat, long = utils.extract_reduced_accuracy_lat_long("-40.20361-40.20361")
+        self.assertEqual(lat, -40.2)
+        self.assertEqual(long, -40.2)
+
+        lat, long = utils.extract_reduced_accuracy_lat_long("-40.20361+40.20361")
+        self.assertEqual(lat, -40.2)
+        self.assertEqual(long, +40.2)
+
+        lat, long = utils.extract_reduced_accuracy_lat_long("+40.20361-40.20361")
+        self.assertEqual(lat, 40.2)
+        self.assertEqual(long, -40.2)
 
         lat, long = utils.extract_reduced_accuracy_lat_long(None)
         self.assertIsNone(lat)

--- a/healthcheck/tests/test_utils.py
+++ b/healthcheck/tests/test_utils.py
@@ -25,7 +25,7 @@ class UtilsTests(TestCase):
 
         lat, long = utils.extract_reduced_accuracy_lat_long("-40.20361+40.20361")
         self.assertEqual(lat, -40.2)
-        self.assertEqual(long, +40.2)
+        self.assertEqual(long, 40.2)
 
         lat, long = utils.extract_reduced_accuracy_lat_long("+40.20361-40.20361")
         self.assertEqual(lat, 40.2)

--- a/healthcheck/utils.py
+++ b/healthcheck/utils.py
@@ -1,7 +1,6 @@
 import base64
 import hashlib
 import os
-import re
 from functools import lru_cache
 
 from google.cloud import bigquery
@@ -92,30 +91,8 @@ def hash_string(text):
 def extract_reduced_accuracy_lat_long(location):
     if location:
         loc = Location(location)
-        lat = round(float(loc.lat.degrees), 1)
-        lng = round(float(loc.lng.degrees), 1)
-        lat_lng = check_negative_lat_lng(location)
-        if lat_lng == "latlng":
-            lat = -lat
-            lng = -lng
-        elif lat_lng == "lat":
-            lat = -lat
-        elif lat_lng == "lng":
-            lng = -lng
+        lat = round(float(loc.lat.decimal), 1)
+        lng = round(float(loc.lng.decimal), 1)
         return (lat, lng)
     else:
         return (None, None)
-
-
-def check_negative_lat_lng(location):
-    (lat, lng) = re.match(
-        r"([+-][0-9]{1,3}\.[0-9]+)([+-][0-9]{1,3}\.[0-9]+)", location
-    ).groups()
-    lat = float(lat)
-    lng = float(lng)
-    if lat < 0 and lng < 0:
-        return "latlng"
-    elif lat < 0 and lng > 0:
-        return "lat"
-    elif lat > 0 and lng < 0:
-        return "lng"

--- a/healthcheck/utils.py
+++ b/healthcheck/utils.py
@@ -119,5 +119,3 @@ def check_negative_lat_lng(location):
         return "lat"
     elif lat > 0 and lng < 0:
         return "lng"
-    else:
-        return None


### PR DESCRIPTION
The location library returns positive longitude and latitude values so we lose the (-).
https://github.com/praekeltfoundation/healthcheck/blob/4d8e5c8df670badccacb5f1d659d7cea7f33dc3b/healthcheck/utils.py#L7

check_negative_lat_lng just checks if the location has a negative part and returns a string for which side is negative. 